### PR TITLE
Support for multiple alarms

### DIFF
--- a/mopidy_alarmclock/__init__.py
+++ b/mopidy_alarmclock/__init__.py
@@ -31,7 +31,7 @@ class Extension(ext.Extension):
         return schema
 
     def setup(self, registry):
-        alarm_manager = AlarmManager()
+        alarm_manager = AlarmManager(self.__class__)
         msg_store = MessageStore()
         registry.add('http:app', {
             'name': self.ext_name,

--- a/mopidy_alarmclock/alarm_manager.py
+++ b/mopidy_alarmclock/alarm_manager.py
@@ -38,6 +38,10 @@ class AlarmManager(object):
 
     def __init__(self):
         self.alarms = [Alarm(),Alarm()]
+    
+    def create_alarm(self):
+        # TODO: Fill out defaults from config file
+        self.alarms.append(Alarm())
 
     def get_core(self, core):
         self.core = core

--- a/mopidy_alarmclock/alarm_manager.py
+++ b/mopidy_alarmclock/alarm_manager.py
@@ -29,7 +29,7 @@ class AlarmManager(object):
     idle_timer = None
 
     def __init__(self):
-        self.alarms = [Alarm()]
+        self.alarms = [Alarm(),Alarm()]
 
     def get_core(self, core):
         self.core = core

--- a/mopidy_alarmclock/alarm_manager.py
+++ b/mopidy_alarmclock/alarm_manager.py
@@ -127,7 +127,7 @@ class AlarmManager(object):
         try:
             current_volume = self.core.playback.volume.get()
         except:
-            logger.warning('Could not get current playback volume')
+            logger.exception('Could not get current playback volume')
             self.core.playback.volume = target_volume
             return
 
@@ -153,7 +153,7 @@ class AlarmManager(object):
             now = datetime.datetime.now()
             if now >= fade_end:
                 logger.debug('Fade deadline has passed, setting volume')
-                self.core.playback_volume = target_volume
+                self.core.playback.volume = target_volume
                 return
 
             # We don't know that we fired at the right time, so we can't

--- a/mopidy_alarmclock/alarm_manager.py
+++ b/mopidy_alarmclock/alarm_manager.py
@@ -22,6 +22,10 @@ class Alarm(object):
     volume_increase_seconds = None  # Seconds to full volume
     state = states.DISABLED
 
+    @property
+    def formatted_ring_time(self):
+        return self.clock_datetime.strftime('%H:%M')
+
 
 class AlarmManager(object):
     core = None
@@ -37,9 +41,6 @@ class AlarmManager(object):
 
     def is_set(self):
         return (self.alarms[0].state == states.WAITING)
-
-    def get_ring_time(self):
-        return self.alarms[0].clock_datetime.strftime('%H:%M')
 
     def get_playlist(self):
         return self.core.playlists.lookup(self.alarms[0].playlist).get()

--- a/mopidy_alarmclock/alarm_manager.py
+++ b/mopidy_alarmclock/alarm_manager.py
@@ -21,6 +21,10 @@ class Alarm(object):
     volume = None  # Alarm volume
     volume_increase_seconds = None  # Seconds to full volume
     state = states.DISABLED
+    enabled = False
+
+    def __init__(self):
+        self.clock_datetime = datetime.datetime.now()
 
     @property
     def formatted_ring_time(self):

--- a/mopidy_alarmclock/alarm_manager.py
+++ b/mopidy_alarmclock/alarm_manager.py
@@ -17,6 +17,7 @@ class Alarm(object):
     volume = None  # Alarm volume
     volume_increase_seconds = None  # Seconds to full volume
     enabled = False
+    days = [ 0, 1, 2, 3, 4, 5, 6 ] # Weekdays the alarm will fire
 
     def __init__(self):
         self.alarm_time = datetime.time()
@@ -30,6 +31,14 @@ class Alarm(object):
         midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
         delta = datetime.timedelta(hours=self.alarm_time.hour, minutes=self.alarm_time.minute)
         return midnight + delta
+
+    @property
+    def set_for_today(self):
+        '''
+        Returns whether the alarm is set to go off on this day of the week.
+        '''
+        today = datetime.datetime.now().weekday()
+        return today in self.days
 
     @property
     def formatted_ring_time(self):
@@ -99,7 +108,7 @@ class AlarmManager(object):
 
         # TODO: Disable the timer if none of our alarms are enabled
         for alarm in self.alarms:
-            if alarm.enabled and self.last_fired < alarm.datetime_today <= now:
+            if alarm.enabled and alarm.set_for_today and self.last_fired < alarm.datetime_today <= now:
                 logger.info('Triggering alarm {}'.format(alarm))
                 self.play(alarm)
                 break  # Assume that multiple alarms don't fire

--- a/mopidy_alarmclock/http.py
+++ b/mopidy_alarmclock/http.py
@@ -55,6 +55,7 @@ class DeleteAlarmRequestHandler(BaseRequestHandler):
             self.send_message('bad')
             return
         del self.alarm_manager.alarms[alarmidx]
+        self.alarm_manager.save_alarms()
         self.send_message('cancel')
 
 
@@ -96,6 +97,7 @@ class SetAlarmRequestHandler(BaseRequestHandler):
             alarm.volume = volume
             alarm.volume_increase_seconds = volume_increase_seconds
             alarm.enabled = enabled
+            self.alarm_manager.save_alarms()
             self.send_message('ok')
         else:
             self.send_message('format')
@@ -111,7 +113,7 @@ def factory_decorator(alarm_manager, msg_store):
     def app_factory(config, core):
         # since all the RequestHandler-classes get the same arguments ...
         def bind(url, klass):
-            return (url, klass, {'config': config, 'core': core, 'alarm_manager': alarm_manager.get_core(core), 'msg_store': msg_store})
+            return (url, klass, {'config': config, 'core': core, 'alarm_manager': alarm_manager.get_core(config, core), 'msg_store': msg_store})
 
         return [
             (r'/static/(.*)', tornado.web.StaticFileHandler, {'path': os.path.join(os.path.dirname(__file__), 'static')}),

--- a/mopidy_alarmclock/http.py
+++ b/mopidy_alarmclock/http.py
@@ -101,7 +101,7 @@ class SetAlarmRequestHandler(BaseRequestHandler):
             alarm.random_mode = random_mode
             alarm.volume = volume
             alarm.volume_increase_seconds = volume_increase_seconds
-            # alarm.state = states.WAITING
+            alarm.enabled = enabled
             self.send_message('ok')
         else:
             self.send_message('format')

--- a/mopidy_alarmclock/http.py
+++ b/mopidy_alarmclock/http.py
@@ -48,8 +48,19 @@ class MainRequestHandler(BaseRequestHandler):
         ))
 
 
+class DeleteAlarmRequestHandler(BaseRequestHandler):
+    def post(self):
+        alarmidx = int(self.get_argument('alarm', -1))
+        if not 0 <= alarmidx < len(self.alarm_manager.alarms):
+            self.send_message('bad')
+            return
+        del self.alarm_manager.alarms[alarmidx]
+        self.send_message('cancel')
+
+
 class SetAlarmRequestHandler(BaseRequestHandler):
     def post(self):
+        # FIXME: Code duplication
         alarmidx = int(self.get_argument('alarm', -1))
         if not 0 <= alarmidx < len(self.alarm_manager.alarms):
             self.send_message('bad')
@@ -57,7 +68,6 @@ class SetAlarmRequestHandler(BaseRequestHandler):
         alarm = self.alarm_manager.alarms[alarmidx]
 
         enabled = bool(self.get_argument('enabled', False))
-
         playlist = self.get_argument('playlist', None)
 
         time_string = self.get_argument('time', None)
@@ -91,12 +101,6 @@ class SetAlarmRequestHandler(BaseRequestHandler):
             self.send_message('format')
 
 
-class CancelAlarmRequestHandler(BaseRequestHandler):
-    def get(self):
-        self.alarm_manager.cancel()
-        self.send_message('cancel')
-
-
 class MessageStore(object):
     msg_code = None  # Message to be stored
 
@@ -114,7 +118,7 @@ def factory_decorator(alarm_manager, msg_store):
 
             bind('/', MainRequestHandler),
             bind('/set/', SetAlarmRequestHandler),
-            bind('/cancel/', CancelAlarmRequestHandler),
+            bind('/delete/', DeleteAlarmRequestHandler),
         ]
 
     return app_factory

--- a/mopidy_alarmclock/http.py
+++ b/mopidy_alarmclock/http.py
@@ -58,6 +58,12 @@ class DeleteAlarmRequestHandler(BaseRequestHandler):
         self.send_message('cancel')
 
 
+class NewAlarmRequestHandler(BaseRequestHandler):
+    def post(self):
+        self.alarm_manager.create_alarm()
+        self.send_message('ok')
+
+
 class SetAlarmRequestHandler(BaseRequestHandler):
     def post(self):
         # FIXME: Code duplication
@@ -117,8 +123,9 @@ def factory_decorator(alarm_manager, msg_store):
             (r'/static/(.*)', tornado.web.StaticFileHandler, {'path': os.path.join(os.path.dirname(__file__), 'static')}),
 
             bind('/', MainRequestHandler),
-            bind('/set/', SetAlarmRequestHandler),
             bind('/delete/', DeleteAlarmRequestHandler),
+            bind('/new/', NewAlarmRequestHandler),
+            bind('/set/', SetAlarmRequestHandler),
         ]
 
     return app_factory

--- a/mopidy_alarmclock/http.py
+++ b/mopidy_alarmclock/http.py
@@ -7,6 +7,8 @@ import re
 import tornado.template
 import tornado.web
 
+from alarm_manager import parse_time
+
 
 template_directory = os.path.join(os.path.dirname(__file__), 'templates')
 template_loader = tornado.template.Loader(template_directory)
@@ -77,9 +79,7 @@ class SetAlarmRequestHandler(BaseRequestHandler):
         enabled = bool(self.get_argument('enabled', False))
         playlist = self.get_argument('playlist', None)
 
-        time_string = self.get_argument('time', None)
-        # Based on RE found here http://stackoverflow.com/a/7536768/927592
-        matched = re.match('^([0-9]|0[0-9]|1[0-9]|2[0-3]):([0-5]?[0-9])$', time_string)
+        time = parse_time(self.get_argument('time', None))
         random_mode = bool(self.get_argument('random', False))
 
         # Get and sanitize volume and seconds to full volume
@@ -89,9 +89,8 @@ class SetAlarmRequestHandler(BaseRequestHandler):
         volume_increase_seconds = int(self.get_argument('incsec', 30))
         volume_increase_seconds = max(min(volume_increase_seconds, 300), 0)
 
-        if matched:
-            time_comp = map(lambda x: int(x), matched.groups())
-            alarm.alarm_time = datetime.time(hour=time_comp[0], minute=time_comp[1])
+        if time is not None:
+            alarm.alarm_time = time
             alarm.playlist = playlist
             alarm.random_mode = random_mode
             alarm.volume = volume

--- a/mopidy_alarmclock/http.py
+++ b/mopidy_alarmclock/http.py
@@ -56,6 +56,8 @@ class SetAlarmRequestHandler(BaseRequestHandler):
             return
         alarm = self.alarm_manager.alarms[alarmidx]
 
+        enabled = bool(self.get_argument('enabled', False))
+
         playlist = self.get_argument('playlist', None)
 
         time_string = self.get_argument('time', None)

--- a/mopidy_alarmclock/http.py
+++ b/mopidy_alarmclock/http.py
@@ -90,13 +90,7 @@ class SetAlarmRequestHandler(BaseRequestHandler):
 
         if matched:
             time_comp = map(lambda x: int(x), matched.groups())
-            time = datetime.time(hour=time_comp[0], minute=time_comp[1])
-
-            dt = datetime.datetime.combine(datetime.datetime.now(), time)
-            if datetime.datetime.now() >= dt:
-                dt += datetime.timedelta(days=1)
-
-            alarm.clock_datetime = dt
+            alarm.alarm_time = datetime.time(hour=time_comp[0], minute=time_comp[1])
             alarm.playlist = playlist
             alarm.random_mode = random_mode
             alarm.volume = volume

--- a/mopidy_alarmclock/templates/index.html
+++ b/mopidy_alarmclock/templates/index.html
@@ -33,25 +33,25 @@
             <input type="hidden" name="alarm" value="{{ i }}">
 
             <div class="form-group">
-              <label class="col-md-4 control-label" for="checkboxes">Enabled</label>
+              <label class="col-md-4 control-label" for="checkboxes-{{ i }}-1">Enabled</label>
               <div class="col-md-4">
-                <label class="checkbox-inline" for="checkboxes-1">
-                  <input name="enabled" id="checkboxes-1" value="1" type="checkbox"{% if alarm.enabled %} checked="checked"{% end %}>
+                <label class="checkbox-inline" for="checkboxes-{{ i }}-1">
+                  <input name="enabled" id="checkboxes-{{ i }}-1" value="1" type="checkbox"{% if alarm.enabled %} checked="checked"{% end %}>
                 </label>
               </div>
             </div>
 
             <div class="form-group clockpicker">
-              <label class="col-md-4 control-label" for="time">Time</label>
+              <label class="col-md-4 control-label" for="time-{{ i }}">Time</label>
               <div class="col-md-4">
-                <input type="text" name="time" class="form-control" value="{{ alarm.formatted_ring_time }}">
+                <input type="text" id="time-{{ i }}" name="time" class="form-control" value="{{ alarm.formatted_ring_time }}">
               </div>
             </div>
 
             <div class="form-group">
-              <label class="col-md-4 control-label" for="playlist">Playlist</label>
+              <label class="col-md-4 control-label" for="playlist-{{ i }}">Playlist</label>
               <div class="col-md-4">
-                <select id="playlist" name="playlist" class="form-control">
+                <select id="playlist-{{ i }}" name="playlist" class="form-control">
                     {% for playlist in playlists %}
                         <option value="{{ playlist.uri }}"{% if alarm.playlist == playlist.uri or alarm.playlist == playlist.name %} selected="selected"{% end %}>{{ playlist.name }}</option>
                     {% end %}
@@ -60,25 +60,25 @@
             </div>
 
             <div class="form-group">
-              <label class="col-md-4 control-label" for="checkboxes">Random Track Order</label>
+              <label class="col-md-4 control-label" for="checkboxes-{{ i }}-0">Random Track Order</label>
               <div class="col-md-4">
-                <label class="checkbox-inline" for="checkboxes-0">
-                  <input name="random" id="checkboxes-0" value="1" type="checkbox"{% if alarm.random_mode %} checked="checked"{% end %}>
+                <label class="checkbox-inline" for="checkboxes-{{ i }}-0">
+                  <input name="random" id="checkboxes-{{ i }}-0" value="1" type="checkbox"{% if alarm.random_mode %} checked="checked"{% end %}>
                 </label>
               </div>
             </div>
 
             <div class="form-group">
-              <label class="col-md-4 control-label" for="volume">Alarm volume</label>
+              <label class="col-md-4 control-label" for="volume-{{ i }}">Alarm volume</label>
               <div class="col-md-4">
-                <input type="range" name="volume" class="form-control volume" min="1" max="100" value="{{ alarm.volume }}" title="{{ alarm.volume }}" onchange="this.title=this.value; this.style.backgroundColor='rgb(255, '+Math.round(this.value*2.55)+', '+Math.round(this.value*2.55)+')';">
+                <input type="range" id="volume-{{ i }}" name="volume" class="form-control volume" min="1" max="100" value="{{ alarm.volume }}" title="{{ alarm.volume }}" onchange="this.title=this.value; this.style.backgroundColor='rgb(255, '+Math.round(this.value*2.55)+', '+Math.round(this.value*2.55)+')';">
               </div>
             </div>
 
             <div class="form-group">
-              <label class="col-md-4 control-label" for="incsec">Seconds to full volume</label>
+              <label class="col-md-4 control-label" for="incsec-{{ i }}">Seconds to full volume</label>
               <div class="col-md-4">
-                <input type="range" name="incsec" class="form-control" min="0" max="300" value="{{ alarm.volume_increase_seconds }}" title="{{ alarm.volume_increase_seconds }}" onchange="this.title=this.value;">
+                <input type="range" id="incsec-{{ i }}" name="incsec" class="form-control" min="0" max="300" value="{{ alarm.volume_increase_seconds }}" title="{{ alarm.volume_increase_seconds }}" onchange="this.title=this.value;">
               </div>
             </div>
 

--- a/mopidy_alarmclock/templates/index.html
+++ b/mopidy_alarmclock/templates/index.html
@@ -9,6 +9,9 @@
 {% end %}
 
 
+<p class="text-center" id="clock"></p>
+
+
 {% for i, alarm in enumerate(alarm_manager.alarms) %}
 <div class="panel panel-default">
 
@@ -90,16 +93,10 @@
 </div>
 {% end %}
 
-
-<p class="text-right">
-    This page was rendered at {{ datetime.datetime.now().strftime('%H:%M') }}.
-</p>
-
 {% end %}
 
 {% block extra-js %}
 <script type="text/javascript">
-{% if alarm_manager.is_set() %}
 var secondsSinceMidnight = {{ alarm_manager.get_seconds_since_midnight() }};
 function updateClock() {
     var hh = Math.floor(secondsSinceMidnight / 3600);
@@ -115,9 +112,8 @@ function updateClock() {
 }
 updateClock();
 window.setInterval(updateClock, 1000);
-{% else %}
+
 $('.clockpicker').clockpicker({'autoclose': true});
 $('#volume').change();
-{% end %}
 </script>
 {% end %}

--- a/mopidy_alarmclock/templates/index.html
+++ b/mopidy_alarmclock/templates/index.html
@@ -22,6 +22,15 @@
 
             <input type="hidden" name="alarm" value="{{ i }}">
 
+            <div class="form-group">
+              <label class="col-md-4 control-label" for="checkboxes">Enabled</label>
+              <div class="col-md-4">
+                <label class="checkbox-inline" for="checkboxes-1">
+                  <input name="enabled" id="checkboxes-1" value="1" type="checkbox"{% if alarm.enabled %} checked="checked"{% end %}>
+                </label>
+              </div>
+            </div>
+
             <div class="form-group clockpicker">
               <label class="col-md-4 control-label" for="time">Time</label>
               <div class="col-md-4">
@@ -64,7 +73,7 @@
             </div>
 
             <div class="form-actions">
-                    <input type="submit" class="btn btn-primary" value="Submit">
+                    <input type="submit" class="btn btn-primary" value="Save">
                     <input type="submit" class="btn btn-danger" value="Delete">
             </div>
 

--- a/mopidy_alarmclock/templates/index.html
+++ b/mopidy_alarmclock/templates/index.html
@@ -64,7 +64,7 @@
             <div class="form-group">
               <label class="col-md-4 control-label" for="volume">Alarm volume</label>
               <div class="col-md-4">
-                <input type="range" name="volume" id="volume" class="form-control" min="1" max="100" value="{{ alarm.volume }}" title="{{ alarm.volume }}" onchange="this.title=this.value; this.style.backgroundColor='rgb(255, '+Math.round(this.value*2.55)+', '+Math.round(this.value*2.55)+')';">
+                <input type="range" name="volume" class="form-control volume" min="1" max="100" value="{{ alarm.volume }}" title="{{ alarm.volume }}" onchange="this.title=this.value; this.style.backgroundColor='rgb(255, '+Math.round(this.value*2.55)+', '+Math.round(this.value*2.55)+')';">
               </div>
             </div>
 
@@ -114,6 +114,6 @@ updateClock();
 window.setInterval(updateClock, 1000);
 
 $('.clockpicker').clockpicker({'autoclose': true});
-$('#volume').change();
+$('.volume').change();
 </script>
 {% end %}

--- a/mopidy_alarmclock/templates/index.html
+++ b/mopidy_alarmclock/templates/index.html
@@ -12,6 +12,13 @@
 <p class="text-center" id="clock"></p>
 
 
+<div class="form-actions">
+  <form class="form-horizontal" action="/alarmclock/new/" method="post">
+    <input type="submit" class="btn btn-success" value="New">
+  </form>
+</div>
+
+
 {% for i, alarm in enumerate(alarm_manager.alarms) %}
 <div class="panel panel-default">
 

--- a/mopidy_alarmclock/templates/index.html
+++ b/mopidy_alarmclock/templates/index.html
@@ -9,40 +9,19 @@
 {% end %}
 
 
-{% if alarm_manager.is_set() %}
-<div class="panel panel-info">
-    <div class="panel-heading">
-        <h3 class="panel-title">Alarm state</h3>
-    </div>
-    <div class="panel-body">
-        <p>
-            The alarm will start at <strong>{{ alarm_manager.get_ring_time() }}</strong> and play playlist <strong>{{ alarm_manager.get_playlist().name }}</strong> with <strong>{{ alarm_manager.volume }}% volume</strong> (time to full volume {{ alarm_manager.volume_increase_seconds }} sec).<br/>
-            <span id="clock"></span><br/>
-           
-            <a role="button" class="btn btn-success btn-large btn-warning" href="/alarmclock/cancel/">Cancel alarm</a>
-        </p>
-    </div>
-</div>
-
-{% else %}
+{% for i, alarm in enumerate(alarm_manager.alarms) %}
 <div class="panel panel-default">
     <div class="panel-heading">
-        <h3 class="panel-title">Alarm state</h3>
+        <h3 class="panel-title">Alarm {{ i+1 }}</h3>
     </div>
     <div class="panel-body">
         <p>
-            No alarm has been set.
-    
             <form class="form-horizontal" action="/alarmclock/set/" method="post"> <!-- TODO proper mention of the app name instead of putting it raw in the URL-->
-
-            <fieldset>
-
-            <legend>Set an alarm</legend>
 
             <div class="form-group clockpicker">
               <label class="col-md-4 control-label" for="time">Time</label>
               <div class="col-md-4">
-                <input type="text" name="time" class="form-control" value="{{ config['def_time'] }}">
+                <input type="text" name="time" class="form-control" value="{{ alarm.clock_datetime }}">
               </div>
             </div>
 
@@ -51,7 +30,7 @@
               <div class="col-md-4">
                 <select id="playlist" name="playlist" class="form-control">
                     {% for playlist in playlists %}
-                        <option value="{{ playlist.uri }}"{% if config['def_playlist'] == playlist.uri or config['def_playlist'] == playlist.name %} selected="selected"{% end %}>{{ playlist.name }}</option>
+                        <option value="{{ playlist.uri }}"{% if alarm.playlist == playlist.uri or alarm.playlist == playlist.name %} selected="selected"{% end %}>{{ playlist.name }}</option>
                     {% end %}
                 </select>
               </div>
@@ -61,7 +40,7 @@
               <label class="col-md-4 control-label" for="checkboxes">Random Track Order</label>
               <div class="col-md-4">
                 <label class="checkbox-inline" for="checkboxes-0">
-                  <input name="random" id="checkboxes-0" value="1" type="checkbox"{% if config['def_random'] %} checked="checked"{% end %}>
+                  <input name="random" id="checkboxes-0" value="1" type="checkbox"{% if alarm.random_mode %} checked="checked"{% end %}>
                 </label>
               </div>
             </div>
@@ -69,22 +48,21 @@
             <div class="form-group">
               <label class="col-md-4 control-label" for="volume">Alarm volume</label>
               <div class="col-md-4">
-                <input type="range" name="volume" id="volume" class="form-control" min="1" max="100" value="{{ config['def_volume'] }}" title="{{ config['def_volume'] }}" onchange="this.title=this.value; this.style.backgroundColor='rgb(255, '+Math.round(this.value*2.55)+', '+Math.round(this.value*2.55)+')';">
+                <input type="range" name="volume" id="volume" class="form-control" min="1" max="100" value="{{ alarm.volume }}" title="{{ alarm.volume }}" onchange="this.title=this.value; this.style.backgroundColor='rgb(255, '+Math.round(this.value*2.55)+', '+Math.round(this.value*2.55)+')';">
               </div>
             </div>
 
             <div class="form-group">
               <label class="col-md-4 control-label" for="incsec">Seconds to full volume</label>
               <div class="col-md-4">
-                <input type="range" name="incsec" class="form-control" min="0" max="300" value="{{ config['def_vol_inc_duration'] }}" title="{{ config['def_vol_inc_duration'] }}" onchange="this.title=this.value;">
+                <input type="range" name="incsec" class="form-control" min="0" max="300" value="{{ alarm.volume_increase_seconds }}" title="{{ alarm.volume_increase_seconds }}" onchange="this.title=this.value;">
               </div>
             </div>
 
             <div class="form-actions">
                     <input type="submit" class="btn btn-primary" value="Submit">
+                    <input type="submit" class="btn btn-primary" value="Delete">
             </div>
-
-           </fieldset>
 
             </form>
         </p>

--- a/mopidy_alarmclock/templates/index.html
+++ b/mopidy_alarmclock/templates/index.html
@@ -83,6 +83,11 @@
 </div>
 {% end %}
 
+
+<p class="text-right">
+    This page was rendered at {{ datetime.datetime.now().strftime('%H:%M') }}.
+</p>
+
 {% end %}
 
 {% block extra-js %}

--- a/mopidy_alarmclock/templates/index.html
+++ b/mopidy_alarmclock/templates/index.html
@@ -11,17 +11,21 @@
 
 {% for i, alarm in enumerate(alarm_manager.alarms) %}
 <div class="panel panel-default">
+
     <div class="panel-heading">
         <h3 class="panel-title">Alarm {{ i+1 }}</h3>
     </div>
+
     <div class="panel-body">
         <p>
             <form class="form-horizontal" action="/alarmclock/set/" method="post"> <!-- TODO proper mention of the app name instead of putting it raw in the URL-->
 
+            <input type="hidden" name="alarm" value="{{ i }}">
+
             <div class="form-group clockpicker">
               <label class="col-md-4 control-label" for="time">Time</label>
               <div class="col-md-4">
-                <input type="text" name="time" class="form-control" value="{{ alarm.clock_datetime }}">
+                <input type="text" name="time" class="form-control" value="{{ alarm.formatted_ring_time }}">
               </div>
             </div>
 
@@ -61,12 +65,11 @@
 
             <div class="form-actions">
                     <input type="submit" class="btn btn-primary" value="Submit">
-                    <input type="submit" class="btn btn-primary" value="Delete">
+                    <input type="submit" class="btn btn-danger" value="Delete">
             </div>
 
             </form>
         </p>
-
     </div>
 </div>
 {% end %}

--- a/mopidy_alarmclock/templates/index.html
+++ b/mopidy_alarmclock/templates/index.html
@@ -73,11 +73,18 @@
             </div>
 
             <div class="form-actions">
-                    <input type="submit" class="btn btn-primary" value="Save">
-                    <input type="submit" class="btn btn-danger" value="Delete">
+              <input type="submit" class="btn btn-primary" value="Save">
             </div>
 
             </form>
+
+            <div class="form-actions">
+              <form class="form-horizontal" action="/alarmclock/delete/" method="post">
+                <input type="hidden" name="alarm" value="{{ i }}">
+                <input type="submit" class="btn btn-danger" value="Delete">
+              </form>
+            </div>
+
         </p>
     </div>
 </div>


### PR DESCRIPTION
I apologize for a pull request that is a heavy refactor. These changes add support for multiple alarms, and generally might make it easier to implement new features in the future.

- Introduces an Alarm model which contains settings for a single alarm.
- Allows each alarm to be enabled or disabled.
- Changes the web UI to allow the creation, deletion, and configuration of multiple alarms.
- Refactors the AlarmManager to greatly simplify the way the idle timer works.
- Rewrites the way the volume fade works.
- Lays the groundwork for weekday settings on alarms.

Not yet done:

- I did not implement any test cases, and probably broke all of the old ones. Coveralls is going to be unhappy.
- New alarms do not get configured with the default settings.
- Alarms are not persisted to disk. (This is not a regression but should be high priority.)
- The UI could use a coat of paint.
- The use of timers could be made much more efficient.